### PR TITLE
Fix GPU attribute initialization and shared memory reader bug

### DIFF
--- a/ImageMat.py
+++ b/ImageMat.py
@@ -202,6 +202,7 @@ class ImageMatProcessor:
         
     def devices_info(self,gpu=True,multi_gpu=-1):
         self.num_devices = ['cpu']
+        self.num_gpus = 0
         if gpu and torch.cuda.is_available():
             self.num_gpus = torch.cuda.device_count()
             if multi_gpu <= 0 or multi_gpu > self.num_gpus:

--- a/generator.py
+++ b/generator.py
@@ -302,7 +302,7 @@ class NumpyUInt8SharedMemoryReader(ImageMatGenerator):
     def validate_img(self, img_idx, img: ImageMat):
         img.require_ndarray()
         img.require_np_uint()
-        stream_key = f'{self.stream_key_prefix}:{i}'
+        stream_key = f'{self.stream_key_prefix}:{img_idx}'
         rd = NumpyUInt8SharedMemoryStreamIO.reader(stream_key, img.data().shape)
         rd.build_buffer()
         self.readers.append(rd)


### PR DESCRIPTION
## Summary
- initialize `num_gpus` to 0 when GPUs aren't used
- fix variable name in `NumpyUInt8SharedMemoryReader`

## Testing
- `python -m py_compile ImageMat.py generator.py processors.py shmIO.py test.py`
- `python test.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684932573c1c8320a709b2b9f0bce365