### PR TITLE
Fix YOLOBlock flow and add tests

### DIFF
--- a/tests/test_yolo_block.py
+++ b/tests/test_yolo_block.py
@@ -1,0 +1,34 @@
+import types
+import sys
+import importlib
+import numpy as np
+
+class FakeYOLO:
+    def __init__(self, modelname, task='detect'):
+        self.modelname = modelname
+        self.task = task
+        self.names = {0: 'fake'}
+    def to(self, device):
+        self.device = device
+        return self
+    def __call__(self, img, conf=0.6, verbose=False):
+        return [f'{self.modelname}-{self.device}']
+
+def test_multiple_images(monkeypatch):
+    fake_module = types.ModuleType('ultralytics')
+    fake_module.YOLO = FakeYOLO
+    monkeypatch.setitem(sys.modules, 'ultralytics', fake_module)
+    import processors
+    importlib.reload(processors)
+
+    YOLOBlock = processors.YOLOBlock
+    ImageMat = processors.ImageMat
+
+    img1 = ImageMat(np.zeros((4,4,3), dtype=np.uint8), 'RGB')
+    img2 = ImageMat(np.zeros((4,4,3), dtype=np.uint8), 'RGB')
+    block = YOLOBlock(modelname='fake')
+    _, meta = block.validate([img1, img2])
+
+    results = meta['YOLO_detections']
+    assert isinstance(results, list)
+    assert len(results) == 2


### PR DESCRIPTION
## Summary
- refine YOLOBlock.validate to avoid recursive forward call
- clean model list handling
- make forward_raw process multiple images
- simplify forward to call forward_raw once
- add unit test for multiple image support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68493370857c8320920686df30dcb914