### PR TITLE
Fix shared memory key creation for readers and writers

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -302,7 +302,7 @@ class NumpyUInt8SharedMemoryReader(ImageMatGenerator):
     def validate_img(self, img_idx, img: ImageMat):
         img.require_ndarray()
         img.require_np_uint()
-        stream_key = f'{self.stream_key_prefix}:{i}'
+        stream_key = f"{self.stream_key_prefix}:{img_idx}"
         rd = NumpyUInt8SharedMemoryStreamIO.reader(stream_key, img.data().shape)
         rd.build_buffer()
         self.readers.append(rd)

--- a/processors.py
+++ b/processors.py
@@ -793,7 +793,7 @@ class NumpyUInt8SharedMemoryWriter(ImageMatProcessor):
     def validate_img(self, img_idx, img: ImageMat):
         img.require_ndarray()
         img.require_np_uint()
-        stream_key = f'{self.stream_key_prefix}:{i}'
+        stream_key = f"{self.stream_key_prefix}:{img_idx}"
         wt = NumpyUInt8SharedMemoryStreamIO.writer(stream_key, img.data().shape)
         wt.build_buffer()
 


### PR DESCRIPTION
## Summary
- use the `img_idx` argument when building shared memory stream keys
- update shared memory reader/writer key construction to use new index

## Testing
- `python -m py_compile generator.py processors.py`


------
https://chatgpt.com/codex/tasks/task_e_6849336c8f9083208a5bb23099a597b1