### PR TITLE
Clean imports

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1,15 +1,11 @@
-from typing import Iterator, Optional, Dict, Any, List, Union
-from typing import Optional, Iterator, Tuple, Any
-import numpy as np
-import cv2
-import cv2
-from ImageMat import *
-from shmIO import NumpyUInt8SharedMemoryStreamIO
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from enum import IntEnum
 
 import cv2
 import numpy as np
-from enum import IntEnum
-from typing import Optional, Iterator
+
+from ImageMat import ColorType, ImageMat, ImageMatGenerator
+from shmIO import NumpyUInt8SharedMemoryStreamIO
 
 class VideoFrameGenerator(ImageMatGenerator):
     """

--- a/processors.py
+++ b/processors.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn.functional as F
 from ultralytics import YOLO
 from shmIO import NumpyUInt8SharedMemoryStreamIO
-from ImageMat import *
+from ImageMat import ImageMat, ImageMatProcessor
 
 class CvDebayerBlock(ImageMatProcessor):
     def __init__(self, format=cv2.COLOR_BAYER_BG2BGR, save_results_to_meta=False):


### PR DESCRIPTION
## Summary
- remove duplicate imports in generator
- import ImageMat symbols explicitly in processors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684bc88e0e848320af0462b96bad7381